### PR TITLE
Update index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -143,4 +143,4 @@ const ping = (host, port = 25565, options, callback) => {
 
 module.exports.Packet = Packet;
 module.exports.Response = Response;
-module.exports = ping;
+module.exports.ping = ping;


### PR DESCRIPTION
Adding the .ping to module.exports in line 146 fixes a TypeError that occurs when trying to use the function from a different file.